### PR TITLE
Changed 0.8+ install instructions to avoid deletion of app.php and db.ph...

### DIFF
--- a/app/views/docs/getting-started/upgrading.md
+++ b/app/views/docs/getting-started/upgrading.md
@@ -21,11 +21,11 @@ lets tar gzip it to a safe location.
 ### Upgrading from 0.8 and above
 
 1.	Download the [latest version](/download)
-2.	Extract the archive and copy/paste/overwrite the `anchor` and `system`
+2.	Backup your current live `anchor/config/app.php` and `anchor/config/db.php` files—we recommend creating a local copy.
+3.	Extract the archive and copy/paste/overwrite the `anchor` and `system`
 	folders and the `index.php` file.
-3.	Rename `anchor/config/database.php` --> `anchor/config/db.php`
-4.	Rename `anchor/config/application.php` --> `anchor/config/app.php`
-5.	Done!
+4.	Upload your downloaded `app.php` and `db.php` files to your new `anchor/config` folder.
+6.	Done!
 
 ### Upgrading from older versions (0.8 and below)
 


### PR DESCRIPTION
...p

I was finding that using Transmit (ftp client), overwriting the `anchor` folder would actually delete my `app.php` and `db.php` files (which is kind of like "undoing" some of the installer and was a pain in the neck to fix). This update method fixes that by instructing the user to download and reupload their app and db files.